### PR TITLE
Add support for buffers

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,6 @@
 {
-  extends: "eslint-config-lob"
+  extends: "lob",
+  globals: {
+    "expect": false
+  }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ node_modules
 
 # Users Environment Variables
 .lock-wscript
+
+# Project-specific .vimrc
+.vimrc

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,10 +8,10 @@ exports.detect = function (buffer) {
   return utils.ascii(buffer, 0, 4) === '%PDF';
 }
 
-exports.measure = function (path) {
+exports.measure = function (pathOrBuffer) {
   return new Promise(function (resolve, reject) {
     try {
-      var doc = new PopplerDocument(path);
+      var doc = new PopplerDocument(pathOrBuffer);
 
       if (doc.pageCount < 1) {
         return reject(new Error('Invalid PDF'));

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var fs     = require('fs');
-var path   = require('path');
-var expect = require('chai').expect;
-var pdf   = require('../lib/index');
+var fs   = require('fs');
+var path = require('path');
+var pdf  = require('../lib/index');
 
 describe('pdf', function () {
 
   describe('detect', function () {
+
     it('should return true for a PDF', function () {
       var pdfPath = path.resolve(__dirname, 'fixtures/pdf/123x456.1.pdf');
       var result = pdf.detect(fs.readFileSync(pdfPath));
@@ -19,6 +19,7 @@ describe('pdf', function () {
       var result = pdf.detect(fs.readFileSync(pngPath));
       expect(result).to.eql(false);
     });
+
   });
 
   describe('measure', function () {
@@ -40,10 +41,10 @@ describe('pdf', function () {
         expectedOutput.pages[i] = { width: width, height: height };
       }
 
-      it('should return the correct dimensions for ' + file, function () {
+      it('should return the correct dimensions for a path to ' + file, function () {
         var pdfPath = path.resolve(fixtures, file);
+
         return pdf.measure(pdfPath)
-        .bind({})
         .then(function (result) {
           for (var i = 0; i < result.pages.length; i++) {
             result.pages[i].width = Math.round(result.pages[i].width);
@@ -52,16 +53,43 @@ describe('pdf', function () {
           expect(result).to.eql(expectedOutput);
         });
       });
+
+      it('should return the correct dimensions for a buffer of ' + file, function () {
+        var pdfPath = path.resolve(fixtures, file);
+        var buffer = fs.readFileSync(pdfPath);
+
+        return pdf.measure(buffer)
+        .then(function (result) {
+          for (var i = 0; i < result.pages.length; i++) {
+            result.pages[i].width = Math.round(result.pages[i].width);
+            result.pages[i].height = Math.round(result.pages[i].height);
+          }
+          expect(result).to.eql(expectedOutput);
+        });
+      });
+
     });
 
-    it('should error with a corrupt PDF', function () {
+    it('should error with a path to a corrupt PDF', function () {
       var pdfPath = path.resolve(__dirname, 'fixtures/corrupt/corrupt.pdf');
       return expect(pdf.measure(pdfPath)).to.be.rejectedWith(Error);
     });
 
-    it('should error with a PDF with no pages', function () {
+    it('should error with a buffer of a corrupt PDF', function () {
+      var pdfPath = path.resolve(__dirname, 'fixtures/corrupt/corrupt.pdf');
+      var buffer = fs.readFileSync(pdfPath);
+      return expect(pdf.measure(buffer)).to.be.rejectedWith(Error);
+    });
+
+    it('should error with a path to a PDF with no pages', function () {
       var pdfPath = path.resolve(__dirname, 'fixtures/corrupt/no_pages.pdf');
       return expect(pdf.measure(pdfPath)).to.be.rejectedWith(Error);
+    });
+
+    it('should error with a buffer of a PDF with no pages', function () {
+      var pdfPath = path.resolve(__dirname, 'fixtures/corrupt/no_pages.pdf');
+      var buffer = fs.readFileSync(pdfPath);
+      return expect(pdf.measure(buffer)).to.be.rejectedWith(Error);
     });
 
   });

--- a/test/setup.test.js
+++ b/test/setup.test.js
@@ -1,5 +1,7 @@
 'use strict';
 
-var chai = require('chai');
+var Chai = require('chai');
 
-chai.use(require('chai-as-promised'));
+Chai.use(require('chai-as-promised'));
+
+global.expect = Chai.expect;


### PR DESCRIPTION
Adds support for buffers. This is required for https://github.com/calipersjs/calipers/issues/58.